### PR TITLE
[feat] 뽀모도로 단계별 알림 표시 추가

### DIFF
--- a/src/app/_components/common/notificationProvider.tsx
+++ b/src/app/_components/common/notificationProvider.tsx
@@ -28,6 +28,10 @@ import type { InvitationNotification } from "@/app/_hooks/_websocket/notificatio
 import type { InvitationResponseNotification } from "@/app/_types/invitations";
 import { useMyInvitations } from "@/app/_hooks/invitations/useMyInvitations";
 import { sendGAEvent } from "@next/third-parties/google";
+import {
+  getTimerNotificationBody,
+  getTimerNotificationTitle,
+} from "@/app/_utils/timerNotification";
 
 type NotificationContextType = {
   showNotification: (message: FocusNotificationMessage) => void;
@@ -107,11 +111,8 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
     (notification: TimerCompletionNotification) => {
       setTimerCompletionNotification(notification);
 
-      const title = notification.todoTitle
-        ? `"${notification.todoTitle}" 타이머 완료!`
-        : "타이머 완료!";
-
-      const body = notification.message || "설정한 시간이 완료되었습니다.";
+      const title = getTimerNotificationTitle(notification);
+      const body = getTimerNotificationBody(notification);
 
       if (permission === "granted") {
         showBrowserNotification(title, {

--- a/src/app/_components/common/notificationProvider.tsx
+++ b/src/app/_components/common/notificationProvider.tsx
@@ -29,6 +29,8 @@ import type { InvitationResponseNotification } from "@/app/_types/invitations";
 import { useMyInvitations } from "@/app/_hooks/invitations/useMyInvitations";
 import { sendGAEvent } from "@next/third-parties/google";
 import {
+  getTimerBrowserNotificationBody,
+  getTimerBrowserNotificationTag,
   getTimerNotificationBody,
   getTimerNotificationTitle,
 } from "@/app/_utils/timerNotification";
@@ -107,34 +109,39 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
     [permission, requestPermission, showBrowserNotification]
   );
 
-  const handleTimerCompletionNotification = useCallback(
+  const showTimerBrowserNotification = useCallback(
     (notification: TimerCompletionNotification) => {
-      setTimerCompletionNotification(notification);
-
       const title = getTimerNotificationTitle(notification);
-      const body = getTimerNotificationBody(notification);
+      const body =
+        getTimerBrowserNotificationBody(notification) ??
+        getTimerNotificationBody(notification);
+      const tag = getTimerBrowserNotificationTag(notification);
+      const options = {
+        body,
+        icon: "/chorme/notificationIcon.png",
+        badge: "/chorme/notificationIcon.png",
+        tag,
+      };
 
       if (permission === "granted") {
-        showBrowserNotification(title, {
-          body: body,
-          icon: "/chorme/notificationIcon.png",
-          badge: "/chorme/notificationIcon.png",
-          tag: `timer-completion-${notification.sessionId}`,
-        });
+        showBrowserNotification(title, options);
       } else if (permission === "default") {
         requestPermission().then((granted) => {
           if (granted) {
-            showBrowserNotification(title, {
-              body: body,
-              icon: "/chorme/notificationIcon.png",
-              badge: "/chorme/notificationIcon.png",
-              tag: `timer-completion-${notification.sessionId}`,
-            });
+            showBrowserNotification(title, options);
           }
         });
       }
     },
     [permission, requestPermission, showBrowserNotification]
+  );
+
+  const handleTimerCompletionNotification = useCallback(
+    (notification: TimerCompletionNotification) => {
+      setTimerCompletionNotification(notification);
+      showTimerBrowserNotification(notification);
+    },
+    [showTimerBrowserNotification]
   );
 
   const handleCloseTimerCompletionModal = useCallback(() => {

--- a/src/app/_components/common/timer/timerComponent.tsx
+++ b/src/app/_components/common/timer/timerComponent.tsx
@@ -23,6 +23,7 @@ import { useBrowserNotification } from "@/app/_hooks/_websocket/notifications/us
 import { useTimerMetrics } from "@/app/_hooks/timers/useTimerMetrics";
 import { sendGAEvent } from "@next/third-parties/google";
 import type { PomodoroSession } from "@/app/api/timers/api";
+import { useNextPomodoro } from "@/app/_hooks/timers/useNextPomodoro";
 
 const CONTENT_FIXED = "h-[110px]";
 
@@ -80,6 +81,7 @@ export default function TimerComponent({
     activeSessionModalOpen,
     closeActiveSessionModal,
   } = useTimerControl({ onSessionIdChange });
+  const nextPomodoroMutation = useNextPomodoro();
 
   const pomoRef = useRef<PomodoroDialHandle>(null);
   const swRef = useRef<StopwatchHandle>(null);
@@ -373,12 +375,24 @@ export default function TimerComponent({
     registerForceStop(onStop);
   }, [onStop, registerForceStop]);
 
+  const syncNextPomodoroPhase = useCallback(async () => {
+    const effectiveSessionId = sessionIdRef.current;
+    if (!effectiveSessionId) return;
+
+    try {
+      await nextPomodoroMutation.mutateAsync(effectiveSessionId);
+    } catch (error) {
+      console.error("뽀모도로 단계 전환 동기화 실패:", error);
+    }
+  }, [nextPomodoroMutation]);
+
   const handlePomodoroComplete = useCallback(async () => {
     if (!pomodoroConfig) return;
     const { focusSeconds, breakSeconds, repeatCount } = pomodoroConfig;
 
     if (currentPhase === "FOCUS") {
       if (currentRound < repeatCount) {
+        await syncNextPomodoroPhase();
         const breakMinutes = breakSeconds / 60;
         setCurrentPhase("BREAK");
         setRunning(true);
@@ -453,6 +467,7 @@ export default function TimerComponent({
 
     setCurrentPhase("FOCUS");
     setCurrentRound(nextRound);
+    await syncNextPomodoroPhase();
     setRunning(true);
     setIsRunning(true);
     const focusMinutes = focusSeconds / 60;
@@ -464,6 +479,7 @@ export default function TimerComponent({
     currentRound,
     onStop,
     setIsRunning,
+    syncNextPomodoroPhase,
     isSupported,
     permission,
     requestPermission,

--- a/src/app/_components/common/timer/timerComponent.tsx
+++ b/src/app/_components/common/timer/timerComponent.tsx
@@ -25,6 +25,7 @@ import { useTimerMetrics } from "@/app/_hooks/timers/useTimerMetrics";
 import { sendGAEvent } from "@next/third-parties/google";
 import { nextPomodoro, type PomodoroSession } from "@/app/api/timers/api";
 import { timerKeys } from "@/app/api/timers/keys";
+import { secondsToHms } from "@/app/_utils/todoTimer";
 
 const CONTENT_FIXED = "h-[110px]";
 const POMODORO_PHASE_SYNC_MAX_ATTEMPTS = 3;
@@ -55,6 +56,7 @@ export default function TimerComponent({
   className,
   initialMode = "pomodoro",
   todoId,
+  defaultTimerSeconds,
   groupId,
   isTaskPublic,
   isTimerPublic,
@@ -63,6 +65,8 @@ export default function TimerComponent({
   className?: string;
   initialMode?: Mode;
   todoId?: string | null;
+  /** 선택된 할일 목표(남은) 시간 — 타이머 모드 시작 시 모달에 자동 입력 */
+  defaultTimerSeconds?: number;
   groupId?: string;
   isTaskPublic?: boolean;
   isTimerPublic?: boolean;
@@ -224,6 +228,49 @@ export default function TimerComponent({
     ]
   );
 
+  const startTimerWithSeconds = useCallback(
+    async (targetSeconds: number) => {
+      if (!todoId || targetSeconds <= 0) return;
+
+      const { hours, minutes, seconds } = secondsToHms(targetSeconds);
+      const config: TimerConfig = {
+        mode: "timer",
+        todoId,
+        participationType: groupId ? "GROUP" : "INDIVIDUAL",
+        groupId,
+        isTaskPublic,
+        isTimerPublic,
+        targetSeconds,
+      };
+
+      cdRef.current?.setTime(hours, minutes, seconds);
+      const session = await startSession(config);
+      if (session) {
+        handleSessionStarted(session, config);
+      }
+    },
+    [
+      todoId,
+      groupId,
+      isTaskPublic,
+      isTimerPublic,
+      startSession,
+      handleSessionStarted,
+    ]
+  );
+
+  useEffect(() => {
+    if (mode !== "timer" || running || isPaused) return;
+
+    if (!defaultTimerSeconds || defaultTimerSeconds <= 0) {
+      cdRef.current?.setTime(0, 0, 0);
+      return;
+    }
+
+    const { hours, minutes, seconds } = secondsToHms(defaultTimerSeconds);
+    cdRef.current?.setTime(hours, minutes, seconds);
+  }, [mode, defaultTimerSeconds, running, isPaused]);
+
   const onStart = useCallback(async () => {
     if (!todoId) {
       sendGAEvent("event", "timer_start_failed", {
@@ -311,6 +358,8 @@ export default function TimerComponent({
         } catch (error) {
           console.error("타이머 재개 실패:", error);
         }
+      } else if (defaultTimerSeconds && defaultTimerSeconds > 0) {
+        await startTimerWithSeconds(defaultTimerSeconds);
       } else {
         setTimerModalOpen(true);
       }
@@ -328,6 +377,8 @@ export default function TimerComponent({
     startTracking,
     startSession,
     handleSessionStarted,
+    defaultTimerSeconds,
+    startTimerWithSeconds,
   ]);
 
   const onPause = useCallback(async () => {
@@ -607,14 +658,19 @@ export default function TimerComponent({
         </div>
       );
     }
+    const preset = defaultTimerSeconds
+      ? secondsToHms(defaultTimerSeconds)
+      : { hours: 0, minutes: 0, seconds: 0 };
+
     return (
       <div className="w-full h-full grid place-items-center">
         <Countdown
+          key={`timer-${todoId ?? "none"}-${defaultTimerSeconds ?? 0}`}
           ref={cdRef}
           className="w-full h-full"
-          hours={0}
-          minutes={0}
-          seconds={0}
+          hours={preset.hours}
+          minutes={preset.minutes}
+          seconds={preset.seconds}
           autoStart={false}
           onComplete={async () => {
             sendGAEvent("event", "timer_complete", {
@@ -662,6 +718,8 @@ export default function TimerComponent({
     permission,
     requestPermission,
     showNotification,
+    defaultTimerSeconds,
+    todoId,
   ]);
 
   const handleTimerEndModalClose = useCallback(() => {
@@ -741,6 +799,7 @@ export default function TimerComponent({
           <TimerModal
             isOpen={timerModalOpen}
             onClose={() => setTimerModalOpen(false)}
+            initialSeconds={defaultTimerSeconds}
             onStart={async (targetSeconds: number) => {
               if (!todoId) {
                 sendGAEvent("event", "timer_start_failed", {
@@ -751,26 +810,9 @@ export default function TimerComponent({
                 setAlertModalOpen(true);
                 return;
               }
-              const config: TimerConfig = {
-                mode: "timer",
-                todoId,
-                participationType: groupId ? "GROUP" : "INDIVIDUAL",
-                groupId,
-                isTaskPublic,
-                isTimerPublic,
-                targetSeconds,
-              };
 
-              // Start Session via hook
-              const session = await startSession(config);
-
-              if (session) {
-                setTimerModalOpen(false);
-                handleSessionStarted(session, config);
-              } else {
-                // If failed or pending modal triggered, just close timer modal
-                setTimerModalOpen(false);
-              }
+              setTimerModalOpen(false);
+              await startTimerWithSeconds(targetSeconds);
             }}
           />
           {timerEndModalOpen && (

--- a/src/app/_components/common/timer/timerComponent.tsx
+++ b/src/app/_components/common/timer/timerComponent.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import clsx from "clsx";
 import TimerSelected from "./timerSelected";
 import TimerButtons from "./timerButton";
@@ -22,10 +23,33 @@ import { usePictureInPicture } from "@/app/_hooks/timers/usePictureInPicture";
 import { useBrowserNotification } from "@/app/_hooks/_websocket/notifications/useBrowserNotification";
 import { useTimerMetrics } from "@/app/_hooks/timers/useTimerMetrics";
 import { sendGAEvent } from "@next/third-parties/google";
-import type { PomodoroSession } from "@/app/api/timers/api";
-import { useNextPomodoro } from "@/app/_hooks/timers/useNextPomodoro";
+import { nextPomodoro, type PomodoroSession } from "@/app/api/timers/api";
+import { timerKeys } from "@/app/api/timers/keys";
 
 const CONTENT_FIXED = "h-[110px]";
+const POMODORO_PHASE_SYNC_MAX_ATTEMPTS = 3;
+const POMODORO_PHASE_SYNC_RETRY_MS = 700;
+
+function wait(milliseconds: number) {
+  return new Promise<void>((resolve) => {
+    window.setTimeout(resolve, milliseconds);
+  });
+}
+
+function getErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isPomodoroPhaseNotFinishedError(message: string) {
+  return (
+    message.includes("현재의 뽀모도로 단계가 아직 종료되지 않았습니다") ||
+    message.includes("PHASE_NOT_FINISHED")
+  );
+}
+
+function isMissingActiveSessionError(message: string) {
+  return message.includes("활성화된 세션이 존재하지 않습니다");
+}
 
 export default function TimerComponent({
   className,
@@ -61,6 +85,8 @@ export default function TimerComponent({
   const [currentRound, setCurrentRound] = useState<number>(1);
 
   const sessionIdRef = useRef<string | null>(null);
+  const isPomodoroPhaseSyncingRef = useRef(false);
+  const isStoppingRef = useRef(false);
   const setSessionId = (value: string | null) => {
     sessionIdRef.current = value;
   };
@@ -81,7 +107,7 @@ export default function TimerComponent({
     activeSessionModalOpen,
     closeActiveSessionModal,
   } = useTimerControl({ onSessionIdChange });
-  const nextPomodoroMutation = useNextPomodoro();
+  const queryClient = useQueryClient();
 
   const pomoRef = useRef<PomodoroDialHandle>(null);
   const swRef = useRef<StopwatchHandle>(null);
@@ -338,36 +364,43 @@ export default function TimerComponent({
   }, [mode, pauseSession, setIsRunning, pauseTracking]);
 
   const onStop = useCallback(async () => {
+    if (isStoppingRef.current) return;
+
+    isStoppingRef.current = true;
     const effectiveSessionId = sessionIdRef.current;
-    finalizeMetrics(
-      mode as "pomodoro" | "stopwatch" | "timer",
-      effectiveSessionId
-    );
+    try {
+      finalizeMetrics(
+        mode as "pomodoro" | "stopwatch" | "timer",
+        effectiveSessionId
+      );
 
-    if (effectiveSessionId) {
-      try {
-        await stopSession(effectiveSessionId);
-      } catch (error) {
-        console.error("타이머 종료 실패:", error);
+      if (effectiveSessionId) {
+        try {
+          await stopSession(effectiveSessionId);
+        } catch (error) {
+          console.error("타이머 종료 실패:", error);
+        }
       }
-    }
 
-    if (mode === "pomodoro") {
-      pomoRef.current?.stop();
-      setPomodoroConfig(null);
-      setCurrentPhase("FOCUS");
-      setCurrentRound(1);
-    } else if (mode === "stopwatch") {
-      swRef.current?.stop();
-    } else {
-      cdRef.current?.reset();
-    }
+      if (mode === "pomodoro") {
+        pomoRef.current?.stop();
+        setPomodoroConfig(null);
+        setCurrentPhase("FOCUS");
+        setCurrentRound(1);
+      } else if (mode === "stopwatch") {
+        swRef.current?.stop();
+      } else {
+        cdRef.current?.reset();
+      }
 
-    setSessionId(null);
-    onSessionIdChange?.(null);
-    setIsPaused(false);
-    setRunning(false);
-    setIsRunning(false);
+      setSessionId(null);
+      onSessionIdChange?.(null);
+      setIsPaused(false);
+      setRunning(false);
+      setIsRunning(false);
+    } finally {
+      isStoppingRef.current = false;
+    }
   }, [mode, stopSession, setIsRunning, onSessionIdChange, finalizeMetrics]);
 
   // GroupPage 등 외부에서 강제 종료할 수 있도록 onStop을 등록
@@ -377,14 +410,47 @@ export default function TimerComponent({
 
   const syncNextPomodoroPhase = useCallback(async () => {
     const effectiveSessionId = sessionIdRef.current;
-    if (!effectiveSessionId) return;
+    if (
+      !effectiveSessionId ||
+      isPomodoroPhaseSyncingRef.current ||
+      isStoppingRef.current
+    ) {
+      return;
+    }
 
+    isPomodoroPhaseSyncingRef.current = true;
     try {
-      await nextPomodoroMutation.mutateAsync(effectiveSessionId);
+      for (let attempt = 1; attempt <= POMODORO_PHASE_SYNC_MAX_ATTEMPTS; attempt += 1) {
+        try {
+          const session = await nextPomodoro(effectiveSessionId);
+          queryClient.setQueryData(timerKeys.current(), session);
+          return;
+        } catch (error) {
+          const message = getErrorMessage(error);
+
+          if (
+            isPomodoroPhaseNotFinishedError(message) &&
+            attempt < POMODORO_PHASE_SYNC_MAX_ATTEMPTS
+          ) {
+            await wait(POMODORO_PHASE_SYNC_RETRY_MS);
+            continue;
+          }
+
+          if (
+            !isMissingActiveSessionError(message) &&
+            !isPomodoroPhaseNotFinishedError(message)
+          ) {
+            console.error("뽀모도로 단계 전환 동기화 실패:", error);
+          }
+          return;
+        }
+      }
     } catch (error) {
       console.error("뽀모도로 단계 전환 동기화 실패:", error);
+    } finally {
+      isPomodoroPhaseSyncingRef.current = false;
     }
-  }, [nextPomodoroMutation]);
+  }, [queryClient]);
 
   const handlePomodoroComplete = useCallback(async () => {
     if (!pomodoroConfig) return;

--- a/src/app/_components/common/timer/timerModal.tsx
+++ b/src/app/_components/common/timer/timerModal.tsx
@@ -1,23 +1,41 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import Image from "next/image";
 import clsx from "clsx";
+import { secondsToHms } from "@/app/_utils/todoTimer";
 
 interface TimerModalProps {
   isOpen: boolean;
   onClose: () => void;
   onStart: (targetSeconds: number) => void;
+  initialSeconds?: number;
 }
 
 export default function TimerModal({
   isOpen,
   onClose,
   onStart,
+  initialSeconds,
 }: TimerModalProps) {
   const [hours, setHours] = useState(0);
   const [minutes, setMinutes] = useState(0);
   const [seconds, setSeconds] = useState(0);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    if (initialSeconds != null && initialSeconds > 0) {
+      const { hours: h, minutes: m, seconds: s } = secondsToHms(initialSeconds);
+      setHours(h);
+      setMinutes(m);
+      setSeconds(s);
+    } else {
+      setHours(0);
+      setMinutes(0);
+      setSeconds(0);
+    }
+  }, [isOpen, initialSeconds]);
 
   const formatTime = (value: number) => {
     return String(value).padStart(2, "0");

--- a/src/app/_components/common/timerCompletionModal.tsx
+++ b/src/app/_components/common/timerCompletionModal.tsx
@@ -2,6 +2,10 @@
 
 import { Button } from "@/components/button";
 import type { TimerCompletionNotification } from "@/app/_hooks/_websocket/notifications/useTimerCompletionNotification";
+import {
+  getTimerNotificationBody,
+  getTimerNotificationTitle,
+} from "@/app/_utils/timerNotification";
 
 type TimerCompletionModalProps = {
   notification: TimerCompletionNotification;
@@ -12,11 +16,8 @@ export default function TimerCompletionModal({
   notification,
   onClose,
 }: TimerCompletionModalProps) {
-  const title = notification.todoTitle
-    ? `"${notification.todoTitle}" 타이머 완료!`
-    : "타이머 완료!";
-
-  const message = notification.message || "설정한 시간이 완료되었습니다.";
+  const title = getTimerNotificationTitle(notification);
+  const message = getTimerNotificationBody(notification);
 
   return (
     <div className="fixed inset-0 bg-black/30 flex items-center justify-center z-[9999]">

--- a/src/app/_components/home/previewMain.tsx
+++ b/src/app/_components/home/previewMain.tsx
@@ -15,6 +15,8 @@ import { useGroupDetail } from "@/app/_hooks/groups/useGroupDetail";
 import { useGroupMemberStatus } from "@/app/_hooks/_websocket/status/useGroupMemberStatus";
 import { useAuthState } from "@/app/_hooks/login/useAuthState";
 import { getUserIdFromToken } from "@/app/_lib/getJwtExp";
+import { getDefaultTimerSecondsFromTodo } from "@/app/_utils/todoTimer";
+import type { Todo } from "@/app/_types/todo";
 
 type PreviewMainProps = {
   state: boolean;
@@ -136,6 +138,20 @@ export default function PreviewMain({ state, groupId, isOnboarding = false, curr
 
   const todoId = validTodoId ?? currentSession?.todo?.id ?? null;
 
+  const selectedTodo = useMemo((): Todo | null => {
+    if (!validTodoId) return null;
+    for (const category of todayTodos) {
+      const found = category.todos.find((todo) => todo.id === validTodoId);
+      if (found) return found;
+    }
+    return null;
+  }, [validTodoId, todayTodos]);
+
+  const defaultTimerSeconds = useMemo(
+    () => getDefaultTimerSecondsFromTodo(selectedTodo),
+    [selectedTodo]
+  );
+
   useEffect(() => {
     setHasSelectedTodo(!!todoId);
   }, [todoId, setHasSelectedTodo]);
@@ -178,6 +194,7 @@ export default function PreviewMain({ state, groupId, isOnboarding = false, curr
 
       <TimerComponent
         todoId={todoId}
+        defaultTimerSeconds={defaultTimerSeconds}
         groupId={groupId}
         isTaskPublic={isTaskPublic}
         isTimerPublic={isTimerPublic}

--- a/src/app/_hooks/_websocket/notifications/useBrowserNotification.ts
+++ b/src/app/_hooks/_websocket/notifications/useBrowserNotification.ts
@@ -45,7 +45,7 @@ export function useBrowserNotification() {
       title: string,
       options?: NotificationOptions
     ): Notification | null => {
-      if (!isSupported) {
+      if (typeof window === "undefined" || !("Notification" in window)) {
         console.warn("Notification API를 지원하지 않는 브라우저입니다.");
         return null;
       }

--- a/src/app/_utils/timerNotification.ts
+++ b/src/app/_utils/timerNotification.ts
@@ -1,0 +1,35 @@
+import type { TimerCompletionNotification } from "@/app/_hooks/_websocket/notifications/useTimerCompletionNotification";
+
+const POMODORO_BREAK_START_MESSAGE = "이제 휴식시간입니다!";
+const POMODORO_FOCUS_START_MESSAGE = "휴식이 끝났어요. 다시 집중할 시간입니다!";
+const POMODORO_COMPLETION_MESSAGE = "뽀모도로가 완료되었습니다!";
+
+export function getTimerNotificationTitle(
+  notification: TimerCompletionNotification
+) {
+  if (notification.mode === "POMODORO") {
+    if (notification.message === POMODORO_BREAK_START_MESSAGE) {
+      return "집중 시간이 끝났어요";
+    }
+
+    if (notification.message === POMODORO_FOCUS_START_MESSAGE) {
+      return "휴식 시간이 끝났어요";
+    }
+
+    if (notification.message === POMODORO_COMPLETION_MESSAGE) {
+      return "뽀모도로 완료!";
+    }
+
+    return "뽀모도로 알림";
+  }
+
+  return notification.todoTitle
+    ? `"${notification.todoTitle}" 타이머 완료!`
+    : "타이머 완료!";
+}
+
+export function getTimerNotificationBody(
+  notification: TimerCompletionNotification
+) {
+  return notification.message || "설정한 시간이 완료되었습니다.";
+}

--- a/src/app/_utils/timerNotification.ts
+++ b/src/app/_utils/timerNotification.ts
@@ -4,6 +4,15 @@ const POMODORO_BREAK_START_MESSAGE = "이제 휴식시간입니다!";
 const POMODORO_FOCUS_START_MESSAGE = "휴식이 끝났어요. 다시 집중할 시간입니다!";
 const POMODORO_COMPLETION_MESSAGE = "뽀모도로가 완료되었습니다!";
 
+const POMODORO_BROWSER_BODY = {
+  focusEnd:
+    "대단해요! 한 세트를 끝내셨네요! 집중한 나를 위해 잠시 숨을 골라보세요.",
+  breakEnd:
+    "휴식 끝! 다시 몰입해볼까요? 몸과 마음이 가벼워졌다면, 다시 집중해봐요!",
+  complete:
+    "타이머가 끝났습니다! 목표를 달성하셨나요? 다 마쳤다면 종료 버튼을, 시간이 더 필요하다면 타이머를 다시 시작해 보세요.",
+} as const;
+
 export function getTimerNotificationTitle(
   notification: TimerCompletionNotification
 ) {
@@ -32,4 +41,47 @@ export function getTimerNotificationBody(
   notification: TimerCompletionNotification
 ) {
   return notification.message || "설정한 시간이 완료되었습니다.";
+}
+
+/** 크롬(브라우저) 알림용 본문. 뽀모도로 단계별 고정 문구, 그 외는 null(기본 본문 사용) */
+export function getTimerBrowserNotificationBody(
+  notification: TimerCompletionNotification
+): string | null {
+  if (notification.mode !== "POMODORO") {
+    return null;
+  }
+
+  if (notification.message === POMODORO_BREAK_START_MESSAGE) {
+    return POMODORO_BROWSER_BODY.focusEnd;
+  }
+
+  if (notification.message === POMODORO_FOCUS_START_MESSAGE) {
+    return POMODORO_BROWSER_BODY.breakEnd;
+  }
+
+  if (notification.message === POMODORO_COMPLETION_MESSAGE) {
+    return POMODORO_BROWSER_BODY.complete;
+  }
+
+  return null;
+}
+
+export function getTimerBrowserNotificationTag(
+  notification: TimerCompletionNotification
+) {
+  const base = `timer-completion-${notification.sessionId}`;
+
+  if (notification.mode === "POMODORO") {
+    if (notification.message === POMODORO_BREAK_START_MESSAGE) {
+      return `${base}-focus-end`;
+    }
+    if (notification.message === POMODORO_FOCUS_START_MESSAGE) {
+      return `${base}-break-end`;
+    }
+    if (notification.message === POMODORO_COMPLETION_MESSAGE) {
+      return `${base}-complete`;
+    }
+  }
+
+  return base;
 }

--- a/src/app/_utils/todoTimer.ts
+++ b/src/app/_utils/todoTimer.ts
@@ -1,0 +1,21 @@
+import type { Todo } from "@/app/_types/todo";
+
+/** 할일에 설정한 목표 시간(초) — 타이머 자동 설정용 */
+export function getDefaultTimerSecondsFromTodo(
+  todo: Todo | null | undefined
+): number | undefined {
+  if (!todo?.targetTimeInSeconds || todo.targetTimeInSeconds <= 0) {
+    return undefined;
+  }
+
+  return todo.targetTimeInSeconds;
+}
+
+export function secondsToHms(totalSeconds: number) {
+  const safe = Math.max(0, Math.floor(totalSeconds));
+  return {
+    hours: Math.floor(safe / 3600),
+    minutes: Math.floor((safe % 3600) / 60),
+    seconds: safe % 60,
+  };
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
<img width="400" alt="image" src="https://github.com/user-attachments/assets/e24b0281-9a24-485e-9265-11b7ed3360f7" />
<img width="400"  alt="image" src="https://github.com/user-attachments/assets/edffb7cc-84c8-461d-8f7f-68125a8cbdcc" />
<img width="400"  alt="image" src="https://github.com/user-attachments/assets/17077478-273d-482a-a699-9eec7080832d" />


- 뽀모도로 단계별 알림 메시지에 맞춰 브라우저 알림/인앱 모달 제목을 분기했습니다.
  - 집중 종료: `집중 시간이 끝났어요`
  - 휴식 종료: `휴식 시간이 끝났어요`
  - 전체 완료: `뽀모도로 완료!`
- 프론트 로컬 뽀모도로 단계 전환 시 백엔드 `nextPomodoro` API를 호출해 서버의 뽀모도로 phase와 동기화되도록 했습니다.
- 프론트 타이머와 서버 시간 차이로 `PHASE_NOT_FINISHED`가 발생하는 경우 짧게 재시도하도록 보정했습니다.
- 중복 단계 전환/중복 종료 호출을 막아 `ACTIVE_SESSION_NOT_FOUND` 노출 가능성을 줄였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
