### PR TITLE
Feat: 그룹방 상단 요약 카드 개편 #257

### DIFF
--- a/src/__tests__/groupFocusCheckApi.test.ts
+++ b/src/__tests__/groupFocusCheckApi.test.ts
@@ -1,0 +1,73 @@
+import {
+  getMyGroupFocusCheck,
+  putGroupNoti,
+  putMyGroupFocusCheck,
+} from "@/app/api/groups/api";
+
+describe("group focus check API", () => {
+  const fetchMock = jest.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    global.fetch = fetchMock;
+  });
+
+  it("개인 수신 설정을 notifications/me에서 조회한다", async () => {
+    fetchMock.mockResolvedValue(response({
+      groupId: "group-1",
+      myFocusCheckEnabled: true,
+    }));
+
+    await getMyGroupFocusCheck("group-1");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/groups/group-1/notifications/me",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("개인 수신 여부만 변경한다", async () => {
+    fetchMock.mockResolvedValue(response({
+      groupId: "group-1",
+      myFocusCheckEnabled: false,
+    }));
+
+    await putMyGroupFocusCheck("group-1", { enabled: false });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/groups/group-1/notifications/me",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ enabled: false }),
+      }),
+    );
+  });
+
+  it("방장 설정에서는 알림 주기만 변경한다", async () => {
+    fetchMock.mockResolvedValue(response({
+      groupId: "group-1",
+      groupName: "study",
+      isNotificationAgreed: true,
+      notificationCycle: 3,
+      notificationMessage: "집중 체크",
+    }));
+
+    await putGroupNoti("group-1", { notificationCycle: 3 });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/groups/group-1/notifications",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ notificationCycle: 3 }),
+      }),
+    );
+  });
+});
+
+function response(data: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ statusCode: 200, message: "OK", data }),
+  } as Response;
+}

--- a/src/app/(pages)/group/_components/groupPage.tsx
+++ b/src/app/(pages)/group/_components/groupPage.tsx
@@ -7,7 +7,8 @@ import Icon from "../../../_components/common/Icons";
 
 import ReviewPopup from "../../../_components/group/review/reviewPopup";
 import GroupTimer from "./sidebar/groupTimer";
-import GroupGoal from "./sidebar/groupGoal";
+import GroupQuote from "./sidebar/groupQuote";
+import GroupPresence from "./sidebar/groupPresence";
 import SidebarButton from "./sidebar/sidebarButton";
 import InviteModal from "@/app/_components/home/room/inviteModal";
 import TimerEndModal from "@/app/_components/common/timerEndModal";
@@ -184,11 +185,16 @@ export default function GroupPage({
     return true;
   }, [isConnected]);
 
-  const participatingMemberCount = useMemo(() => {
+  const realtimeParticipatingMemberCount = useMemo(() => {
     return Array.from(memberStatuses.values()).filter(
       (status) => status.participationStatus !== "NOT_PARTICIPATING",
     ).length;
   }, [memberStatuses]);
+
+  const participatingMemberCount =
+    realtimeParticipatingMemberCount ||
+    groupData.participatingMemberCount ||
+    0;
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -205,39 +211,34 @@ export default function GroupPage({
 
   return (
     <div className="flex flex-col items-center w-full gap-5">
-      <div className="flex gap-5 w-full">
+      <div className="hidden" aria-hidden="true">
+        <GroupTimer
+          groupId={groupData.groupId}
+          initialAccumulatedDuration={groupData.accumulatedDuration || 0}
+          onSessionIdChange={setSessionId}
+          onStatusChange={setTimerStatus}
+          memberStatuses={memberStatuses}
+        />
+      </div>
+      <div className="flex w-full gap-5">
         <div
-          className={`flex flex-col gap-3 bg-white px-8 py-5 rounded-2xl ${onboardingStep === 1 ? "border-4 border-red-200 shadow-[0_0_30px_5px_rgba(0,0,0,0.2)]" : ""}`}
+          className={`min-w-0 flex-3 ${onboardingStep === 1 ? "rounded-2xl border-4 border-red-200 shadow-[0_0_30px_5px_rgba(0,0,0,0.2)]" : ""}`}
         >
-          <h3 className="text-heading4-20SB text-black">그룹 타이머</h3>
-          <GroupTimer
-            groupId={groupData.groupId}
-            initialAccumulatedDuration={groupData.accumulatedDuration || 0}
-            onSessionIdChange={setSessionId}
-            onStatusChange={setTimerStatus}
-            memberStatuses={memberStatuses}
-          />
+          <GroupQuote />
         </div>
-        <div className="w-full">
-          <div className="flex gap-5 h-full">
-            <div
-              className={`w-full ${onboardingStep === 2 ? "rounded-2xl border-4 border-red-200 shadow-[0_0_30px_5px_rgba(0,0,0,0.2)]" : ""
-                }`}
-            >
-              <GroupGoal data={groupData} isHost={isHost} />
-            </div>
-
-            <div
-              className={`w-full ${onboardingStep === 2 ? "rounded-2xl border-4 border-red-200 shadow-[0_0_30px_5px_rgba(0,0,0,0.2)]" : ""
-                }`}
-            >
-              <GroupNoti
-                data={groupData}
-                isHost={isHost}
-                isOnboarding={onboardingStep !== undefined}
-              />
-            </div>
-          </div>
+        <div
+          className={`min-w-0 flex-3 ${onboardingStep === 2 ? "rounded-2xl border-4 border-red-200 shadow-[0_0_30px_5px_rgba(0,0,0,0.2)]" : ""}`}
+        >
+          <GroupPresence participatingMemberCount={participatingMemberCount} />
+        </div>
+        <div
+          className={`min-w-0 flex-2 ${onboardingStep === 2 ? "rounded-2xl border-4 border-red-200 shadow-[0_0_30px_5px_rgba(0,0,0,0.2)]" : ""}`}
+        >
+          <GroupNoti
+            data={groupData}
+            isHost={isHost}
+            isOnboarding={onboardingStep !== undefined}
+          />
         </div>
       </div>
 
@@ -245,7 +246,7 @@ export default function GroupPage({
         <div className="flex justify-between mb-2">
           <p className="text-heading4-20R text-gray-600 mb-3">
             <b className="text-black">그룹원</b> {participatingMemberCount}/
-            {groupData.members.length}
+            {groupData.totalMemberCount ?? groupData.members.length}
           </p>
           <SidebarButton
             className={`px-7 py-2 cursor-pointer ${onboardingStep === 3 ? "border-4 border-red-200 shadow-[0_0_30px_5px_rgba(0,0,0,0.2)] font-bold" : ""}`}

--- a/src/app/(pages)/group/_components/sidebar/groupNoti.tsx
+++ b/src/app/(pages)/group/_components/sidebar/groupNoti.tsx
@@ -7,9 +7,6 @@ import NotiModal from "../../../../_components/group/modal/notiModal";
 import { GroupDetail } from "@/app/_types/groups";
 import ToggleButton from "@/app/_components/group/modal/toggleButton";
 import { useToggleNotification } from "@/app/_hooks/groups/useToggleNotification";
-import { useFocusNotification } from "@/app/_hooks/_websocket/notifications/useFocusNotification";
-import { useQueryClient } from "@tanstack/react-query";
-import { groupKeys } from "@/app/api/groups/keys";
 
 type GroupNotiProps = {
   data: GroupDetail;
@@ -17,86 +14,67 @@ type GroupNotiProps = {
   isOnboarding?: boolean;
 };
 
-export default function GroupNoti({ data, isHost, isOnboarding }: GroupNotiProps) {
+const getCycleLabel = (hours: number) =>
+  hours === 1 ? "매 시 정각" : `${hours}시간마다`;
+
+export default function GroupNoti({
+  data,
+  isHost,
+  isOnboarding,
+}: GroupNotiProps) {
   const [openNoti, setOpenNoti] = useState(false);
-  const queryClient = useQueryClient();
+  const { notiData, localEnabled, handleToggle, isReady } =
+    useToggleNotification(data.groupId);
 
-  useFocusNotification({
-    groupId: data.groupId,
-    onNotification: (message) => {
-      if (message.groupId === data.groupId) {
-        queryClient.invalidateQueries({
-          queryKey: groupKeys.notifications(data.groupId),
-        });
-      }
-    },
-  });
-
-  const { notiData, localAgreed, handleToggle } = useToggleNotification(
-    data.groupId,
-  );
-
-  const displayNotiData = isOnboarding
-    ? { notificationCycle: 1, notificationMessage: "집중 체크 시간입니다!" } // 1시간 설정
-    : notiData;
-
-  const displayLocalAgreed = isOnboarding ? true : localAgreed;
+  const notificationCycle = isOnboarding
+    ? 1
+    : notiData?.notificationCycle;
+  const displayEnabled = isOnboarding ? true : localEnabled;
 
   return (
     <>
-      <div className="flex flex-col h-full justify-center items-center bg-white px-8 py-6 rounded-2xl w-full">
+      <div className="flex h-full w-full flex-col items-center justify-center rounded-2xl bg-white px-8 py-5">
         <h3 className="text-heading4-20SB text-black">집중 체크 알림</h3>
-        {displayNotiData ? (
+        {isOnboarding || (isReady && notificationCycle) ? (
           <>
-            <div className="flex items-center gap-1 mt-4 mb-4">
-              <p
-                className={`text-heading2-28SB ${displayLocalAgreed ? "text-gray-800" : "text-gray-400"
-                  }`}
-              >
-                {String(displayNotiData.notificationCycle).padStart(2, "0")}
+            <div className="mt-5 flex items-center gap-1">
+              <p className="text-center text-heading2-28SB text-black">
+                {getCycleLabel(notificationCycle ?? 1)}
               </p>
-              <p className="text-body1-16R text-gray-600">시간</p>
-
-              {isHost && (
-                <button onClick={() => setOpenNoti(true)} className="ml-1">
+              {isHost && !isOnboarding && (
+                <button
+                  type="button"
+                  onClick={() => setOpenNoti(true)}
+                  className="ml-1"
+                  aria-label="집중 체크 주기 설정"
+                >
                   <Icon Svg={Edit} size={24} className="text-gray-600" />
                 </button>
               )}
             </div>
-
-            <div className="relative group">
+            <div className="mt-5 flex w-full justify-center">
               <ToggleButton
-                checked={displayLocalAgreed}
-                onChange={(e) => handleToggle(e.target.checked)}
-                disabled={!isHost}
+                checked={displayEnabled}
+                onChange={(event) => handleToggle(event.target.checked)}
+                disabled={isOnboarding}
               />
-              {!isHost && (
-                <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-1.5 bg-gray-800 text-white text-body2-14R rounded-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap">
-                  방장이 대표로 관리하고 있어요
-                  <div className="absolute top-full left-1/2 -translate-x-1/2 -mt-1 border-4 border-transparent border-t-gray-800" />
-                </div>
-              )}
             </div>
           </>
         ) : (
-          <div className="mt-4 h-20 animate-pulse bg-gray-100 rounded-lg w-full" />
+          <div className="mt-4 h-20 w-full animate-pulse rounded-lg bg-gray-100" />
         )}
       </div>
 
-      {openNoti && displayNotiData && (
+      {openNoti && notificationCycle && (
         <div
-          className="fixed inset-0 bg-black/30 flex items-center justify-center z-50"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/30"
           onClick={() => setOpenNoti(false)}
         >
-          <div className="relative" onClick={(e) => e.stopPropagation()}>
+          <div className="relative" onClick={(event) => event.stopPropagation()}>
             <NotiModal
               onClose={() => setOpenNoti(false)}
               groupId={data.groupId}
-              initialData={{
-                isAgreed: displayLocalAgreed,
-                hours: displayNotiData.notificationCycle,
-                message: displayNotiData.notificationMessage,
-              }}
+              initialData={{ hours: notificationCycle }}
             />
           </div>
         </div>

--- a/src/app/(pages)/group/_components/sidebar/groupPresence.tsx
+++ b/src/app/(pages)/group/_components/sidebar/groupPresence.tsx
@@ -1,0 +1,21 @@
+type GroupPresenceProps = {
+  participatingMemberCount: number;
+};
+
+export default function GroupPresence({
+  participatingMemberCount,
+}: GroupPresenceProps) {
+  return (
+    <div className="flex h-full min-w-0 flex-col gap-3 rounded-2xl bg-white px-8 py-5">
+      <h3 className="text-heading4-20SB text-black">라운지 현황</h3>
+      <div className="flex h-[108px] flex-1 flex-col items-center justify-center rounded-2xl border border-gray-200 bg-gray-100 px-6 py-6 text-gray-700">
+        <p className="text-center text-heading2-28SB">
+          {participatingMemberCount}명 🔥
+        </p>
+        <p className="mt-2 text-center text-body1-16R text-gray-600">
+          함께 몰입 중입니다
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(pages)/group/_components/sidebar/groupQuote.tsx
+++ b/src/app/(pages)/group/_components/sidebar/groupQuote.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useProfile } from "@/app/_hooks/mypage/useProfile";
+
+export default function GroupQuote() {
+  const { data: profile, isPending } = useProfile();
+  const content = profile?.quote?.content?.trim();
+
+  return (
+    <div className="flex h-full min-w-0 flex-col gap-3 rounded-2xl bg-white px-8 py-5">
+      <h3 className="text-heading4-20SB text-black">오늘의 한마디</h3>
+      <div className="flex h-[108px] flex-1 items-center justify-center overflow-y-auto rounded-2xl border border-gray-200 bg-gray-100 px-10 py-8 text-gray-700">
+        <p className="text-center text-body1-16R leading-7">
+          {isPending
+            ? "명언을 불러오는 중이에요."
+            : content || "오늘의 한마디가 아직 없어요."}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/_components/group/modal/notiModal.tsx
+++ b/src/app/_components/group/modal/notiModal.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react";
 import { Button } from "@/components/button";
 import GroupModal from "./groupModal";
-import ToggleButton from "./toggleButton";
 import Image from "next/image";
 import { useUpdateGroupNotifications } from "@/app/_hooks/groups/useUpdateGroupNotifications";
 
@@ -11,9 +10,7 @@ interface NotiModalProps {
   onClose: () => void;
   groupId: string;
   initialData: {
-    isAgreed: boolean;
     hours: number;
-    message: string | null;
   };
 }
 
@@ -22,9 +19,7 @@ export default function NotiModal({
   groupId,
   initialData,
 }: NotiModalProps) {
-  const [isAgreed, setIsAgreed] = useState(initialData.isAgreed);
   const [hours, setHours] = useState(initialData.hours);
-  const [message, setMessage] = useState(initialData.message || "");
 
   const { mutateAsync: updateNoti, isPending: isUpdating } =
     useUpdateGroupNotifications(groupId);
@@ -32,9 +27,7 @@ export default function NotiModal({
   const handleSubmit = async () => {
     try {
       await updateNoti({
-        isNotificationAgreed: isAgreed,
         notificationCycle: hours,
-        notificationMessage: message,
       });
       onClose();
     } catch (e) {
@@ -43,43 +36,26 @@ export default function NotiModal({
   };
 
   const increase = () => {
-    if (!isAgreed) return;
     setHours((prev) => Math.min(99, prev + 1));
   };
 
   const decrease = () => {
-    if (!isAgreed) return;
     setHours((prev) => Math.max(1, prev - 1));
   };
 
   return (
     <GroupModal onClose={onClose}>
       <div className="flex flex-col px-7 py-4">
-        <h2 className="text-heading4-20SB text-center">집중 체크 알림</h2>
+        <h2 className="text-heading4-20SB text-center">집중 체크 주기 설정</h2>
         <p className="text-body1-16R text-gray-700 mt-2 text-center">
-          그룹원들의 집중 유지를 위한 주기적 알림 장치입니다.
+          그룹원에게 집중 체크 알림을 보낼 주기를 설정합니다.
         </p>
 
-        <p className="text-body1-16SB mt-7">알림 기능 사용</p>
-
-        <div className="flex gap-3 items-center mt-3 mb-7">
-          <ToggleButton
-            checked={isAgreed}
-            onChange={(e) => setIsAgreed(e.target.checked)}
-          />
-          <p className="text-body2-14R text-gray-600">
-            {isAgreed ? "알림을 받을게요" : "알림을 안 받을래요"}
-          </p>
-        </div>
-
-        <p className={`text-body1-16SB mt-7 ${!isAgreed && "text-gray-400"}`}>
-          알림 주기
-        </p>
+        <p className="text-body1-16SB mt-7">알림 주기</p>
 
         <div className="mt-3 mb-7 w-full">
           <div
-            className={`flex items-center justify-between px-5 py-1.5 rounded-lg border bg-gray-100 border-gray-200 ${!isAgreed ? "opacity-50" : ""
-              }`}
+            className="flex items-center justify-between px-5 py-1.5 rounded-lg border bg-gray-100 border-gray-200"
           >
             <div className="flex-1 text-center">
               <span className="text-body1-16SB text-gray-800">{hours}</span>
@@ -89,7 +65,6 @@ export default function NotiModal({
             <div className="flex flex-col ml-4">
               <button
                 onClick={increase}
-                disabled={!isAgreed}
                 className="w-6 h-5 flex items-center justify-center text-gray-500 hover:text-gray-700 disabled:opacity-40"
               >
                 <Image
@@ -101,7 +76,6 @@ export default function NotiModal({
               </button>
               <button
                 onClick={decrease}
-                disabled={!isAgreed}
                 className="w-6 h-5 flex items-center justify-center text-gray-500 hover:text-gray-700 disabled:opacity-40"
               >
                 <Image
@@ -113,24 +87,6 @@ export default function NotiModal({
               </button>
             </div>
           </div>
-        </div>
-
-        <p className={`text-body1-16SB mt-7 ${!isAgreed && "text-gray-400"}`}>
-          알림 메시지
-        </p>
-
-        <div
-          className={`bg-gray-100 px-5 py-3 rounded-lg w-full border border-gray-200 mt-3 mb-7 ${!isAgreed ? "opacity-50" : ""
-            }`}
-        >
-          <input
-            type="text"
-            disabled={!isAgreed}
-            value={message}
-            onChange={(e) => setMessage(e.target.value)}
-            className="w-full bg-gray-100 border-none outline-none text-body2-14R"
-            placeholder="텍스트를 입력해주세요"
-          />
         </div>
 
         <Button

--- a/src/app/_hooks/groups/useGetMyGroupFocusCheck.ts
+++ b/src/app/_hooks/groups/useGetMyGroupFocusCheck.ts
@@ -1,0 +1,11 @@
+import { getMyGroupFocusCheck } from "@/app/api/groups/api";
+import { groupKeys } from "@/app/api/groups/keys";
+import { useQuery } from "@tanstack/react-query";
+
+export const useGetMyGroupFocusCheck = (groupId: string) =>
+  useQuery({
+    queryKey: groupKeys.focusCheck(groupId),
+    queryFn: () => getMyGroupFocusCheck(groupId),
+    enabled: !!groupId,
+    staleTime: 30 * 1000,
+  });

--- a/src/app/_hooks/groups/useToggleNotification.ts
+++ b/src/app/_hooks/groups/useToggleNotification.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { useGetGroupNotifications } from "./useGetGroupNotifications";
-import { useUpdateGroupNotifications } from "./useUpdateGroupNotifications";
+import { useGetMyGroupFocusCheck } from "./useGetMyGroupFocusCheck";
+import { useUpdateMyGroupFocusCheck } from "./useUpdateMyGroupFocusCheck";
 
 /**
  * 그룹 알림 토글 상태를 관리하는 커스텀 훅
@@ -8,39 +9,37 @@ import { useUpdateGroupNotifications } from "./useUpdateGroupNotifications";
  * @returns 알림 데이터, 로컬 토글 상태, 토글 핸들러
  */
 export function useToggleNotification(groupId: string) {
-    const [localAgreed, setLocalAgreed] = useState(false);
+    const [localEnabled, setLocalEnabled] = useState(true);
 
     const { data: notiData } = useGetGroupNotifications(groupId);
-    const { mutateAsync: updateNoti } = useUpdateGroupNotifications(groupId);
+    const { data: focusCheckData } = useGetMyGroupFocusCheck(groupId);
+    const { mutateAsync: updateFocusCheck } = useUpdateMyGroupFocusCheck(groupId);
 
     // 서버 데이터로 로컬 상태 동기화
     useEffect(() => {
-        if (notiData) {
-            setLocalAgreed(notiData.isNotificationAgreed);
+        if (focusCheckData) {
+            setLocalEnabled(focusCheckData.myFocusCheckEnabled);
         }
-    }, [notiData]);
+    }, [focusCheckData]);
 
     const handleToggle = (checked: boolean) => {
-        if (!notiData) return;
+        if (!focusCheckData) return;
 
         // 낙관적 업데이트: 즉시 UI 반영
-        setLocalAgreed(checked);
+        setLocalEnabled(checked);
 
         // 백그라운드에서 서버 업데이트 (await 제거)
-        updateNoti({
-            isNotificationAgreed: checked,
-            notificationCycle: notiData.notificationCycle,
-            notificationMessage: notiData.notificationMessage,
-        }).catch((e) => {
+        updateFocusCheck(checked).catch((e) => {
             console.error("알림 설정 업데이트 실패:", e);
             // 실패 시 롤백
-            setLocalAgreed(!checked);
+            setLocalEnabled(!checked);
         });
     };
 
     return {
         notiData,
-        localAgreed,
+        localEnabled,
         handleToggle,
+        isReady: !!notiData && !!focusCheckData,
     };
 }

--- a/src/app/_hooks/groups/useUpdateMyGroupFocusCheck.ts
+++ b/src/app/_hooks/groups/useUpdateMyGroupFocusCheck.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { putMyGroupFocusCheck } from "@/app/api/groups/api";
+import { groupKeys } from "@/app/api/groups/keys";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+export const useUpdateMyGroupFocusCheck = (groupId: string) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (enabled: boolean) =>
+      putMyGroupFocusCheck(groupId, { enabled }),
+    onSuccess: (data) => {
+      queryClient.setQueryData(groupKeys.focusCheck(groupId), data);
+    },
+  });
+};

--- a/src/app/_types/groups.ts
+++ b/src/app/_types/groups.ts
@@ -113,6 +113,8 @@ export type GroupDetail = {
   members: GroupMembers;
   progressRate: number;
   groupGoal: GroupGoal;
+  participatingMemberCount?: number;
+  totalMemberCount?: number;
 };
 
 // 그룹 공동 목표
@@ -149,9 +151,7 @@ export type GroupMemberStatus = {
 
 // 알림
 export type NotiReq = {
-  isNotificationAgreed: boolean;
   notificationCycle: number;
-  notificationMessage: string;
 };
 
 export type NotiRes = {
@@ -160,6 +160,15 @@ export type NotiRes = {
   isNotificationAgreed: boolean;
   notificationCycle: number;
   notificationMessage: string;
+};
+
+export type GroupFocusCheckReq = {
+  enabled: boolean;
+};
+
+export type GroupFocusCheckRes = {
+  groupId: string;
+  myFocusCheckEnabled: boolean;
 };
 
 //  목표시간

--- a/src/app/api/groups/api.ts
+++ b/src/app/api/groups/api.ts
@@ -14,6 +14,8 @@ import type {
   CommonGroup,
   PokeRequest,
   GroupHostAckStatus,
+  GroupFocusCheckReq,
+  GroupFocusCheckRes,
 } from "@/app/_types/groups";
 import { request } from "../request";
 
@@ -176,6 +178,20 @@ export const putGroupNoti = (groupId: string, payload: NotiReq) =>
 export const getGroupNoti = (groupId: string) =>
   request<NotiRes>(GROUPS_BASE, `/${groupId}/notifications`, {
     method: "GET",
+  });
+
+export const getMyGroupFocusCheck = (groupId: string) =>
+  request<GroupFocusCheckRes>(GROUPS_BASE, `/${groupId}/notifications/me`, {
+    method: "GET",
+  });
+
+export const putMyGroupFocusCheck = (
+  groupId: string,
+  payload: GroupFocusCheckReq,
+) =>
+  request<GroupFocusCheckRes>(GROUPS_BASE, `/${groupId}/notifications/me`, {
+    method: "PUT",
+    body: JSON.stringify(payload),
   });
 
 export const putGroupGoal = (groupId: string, payload: GroupGoalReq) =>

--- a/src/app/api/groups/keys.ts
+++ b/src/app/api/groups/keys.ts
@@ -12,6 +12,8 @@ export const groupKeys = {
   detail: (groupId: string) => [...groupKeys.all(), "detail", groupId] as const,
   notifications: (groupId: string) =>
     [...groupKeys.all(), "notifications", groupId] as const,
+  focusCheck: (groupId: string) =>
+    [...groupKeys.all(), "focus-check", groupId] as const,
   goal: (groupId: string) => [...groupKeys.all(), "goal", groupId] as const,
   invitations: (groupId: string) =>
     [...groupKeys.all(), "invitations", groupId] as const,


### PR DESCRIPTION
## #️⃣연관된 이슈

Closes #257

Backend dependencies:
- https://github.com/mogakjak/mogakjak-be/issues/87
- https://github.com/mogakjak/mogakjak-be/pull/94

## 📝작업 내용

- 그룹방 상단을 오늘의 한마디·라운지 현황·집중 체크 알림 카드로 개편
- 오늘의 한마디는 기존 프로필 quote 응답 재사용
- 참여 인원은 그룹 상세 participatingMemberCount를 지원하고 WebSocket 상태를 실시간 값으로 사용
- 방장과 멤버 모두 개인 집중 체크 토글 사용
- 방장에게만 알림 주기 설정 UI 제공
- 그룹 전체 ON/OFF와 알림 메시지 입력 UI 제거
- 기존 그룹 타이머 UI는 숨기되 상태 구독과 나가기 시 종료 동작은 유지
- 개인 설정 GET/PUT notifications/me API 테스트 추가

### 스크린샷 (선택)

To-Be 시안 기준으로 상단 3개 카드 구조를 적용했습니다.

## 💬리뷰 요구사항(선택)

- 배포 순서: 백엔드 PR #94와 백엔드 #87 구현이 프론트보다 먼저 반영되어야 합니다.
- 백엔드 #87 반영 전에도 WebSocket 멤버 상태로 참여 인원을 표시하지만, 최초 로딩 값은 participatingMemberCount 계약에 의존합니다.
- npm test -- --runInBand: 6 suites, 45 tests 통과
- npm run build: 성공
- 기존 파일의 ESLint warning 2건은 이번 변경 범위에 포함하지 않았습니다.
- 인증된 실제 서버를 사용한 브라우저 E2E는 백엔드 의존성 배포 후 수행해야 합니다.